### PR TITLE
Handle 'null' values in json file

### DIFF
--- a/pi_top_usb_setup/app_fs.py
+++ b/pi_top_usb_setup/app_fs.py
@@ -104,7 +104,7 @@ class AppFilesystem:
             "keyboard_layout": lambda layout_and_variant_arr: set_keyboard_layout(
                 *layout_and_variant_arr
             ),
-            "registration_email": set_registration_email,
+            "email": set_registration_email,
         }
 
         logger.info(f"Configuring device using {self.DEVICE_CONFIG}")
@@ -117,8 +117,15 @@ class AppFilesystem:
                 logger.info(f"'{key}' not found in configuration file, skipping...")
                 continue
 
+            args = config.get(key)
+            if args is None:
+                logger.info(
+                    f"Arguments for '{key}' not found in configuration file, skipping..."
+                )
+                continue
+
             try:
-                logger.info(f"{key}: Executing {function} with '{config.get(key)}'")
+                logger.info(f"{key}: Executing {function} with '{args}'")
                 function(config.get(key))
                 if callable(on_progress):
                     on_progress(float(100.0 * i / len(lookup)))

--- a/pi_top_usb_setup/app_fs.py
+++ b/pi_top_usb_setup/app_fs.py
@@ -120,7 +120,7 @@ class AppFilesystem:
             args = config.get(key)
             if args is None:
                 logger.info(
-                    f"Arguments for '{key}' not found in configuration file, skipping..."
+                    f"Value for '{key}' not found in configuration file, skipping..."
                 )
                 continue
 


### PR DESCRIPTION
- Don't run onboarding/setup functions if value provided in json file is `null` (`None`).
- Use `email` instead of `registration_email` as key in the json file for registering the device.