### PR TITLE
Support setup-file variations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
     - id: check-symlinks
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
     - id: isort
       args: ["--profile", "black"]
 
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 24.4.2
     hooks:
     - id: black
 
@@ -26,7 +26,7 @@ repos:
     - id: autopep8
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.1.0
     hooks:
     - id: flake8
       name: flake8

--- a/extra/handle-usb-drive-for-pi-top-setup
+++ b/extra/handle-usb-drive-for-pi-top-setup
@@ -81,7 +81,13 @@ start_miniscreen_app() {
 }
 
 has_pitop_offline_setup_files() {
-    if [ -f "${MOUNT_POINT}/pi-top-usb-setup.tar.gz" ] || [ -f "${MOUNT_POINT}/pi-top-usb-setup/updates.tar.gz" ] || [ -d "${MOUNT_POINT}/pi-top-usb-setup/updates" ]; then
+    # look for setup files
+    if find "${MOUNT_POINT}" -maxdepth 1 -type f -name "pi-top-usb-setup*.tar.gz"| grep -q .; then
+        return 0
+    fi
+
+    # look for already extracted content
+    if [ -f "${MOUNT_POINT}/pi-top-usb-setup/updates.tar.gz" ] || [ -d "${MOUNT_POINT}/pi-top-usb-setup/updates" ]; then
         return 0
     fi
     return 1


### PR DESCRIPTION
- In the case where multiple setup-files are found but with slightly different names, use the most recent one.
- Use the `pi-top-usb-setup*.tar.gz` pattern to find setup files. This will match the original setup-file name `pi-top-usb-setup.tar.gz` and variations such as `pi-top-usb-setup (5).tar.gz`