### PR TITLE
Generate update file for bookworm

### DIFF
--- a/.github/workflows/create-usb-setup-file.yml
+++ b/.github/workflows/create-usb-setup-file.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           name: files-${{ matrix.DISTRO }}
           path: |
-            packages.list
+            *.list
             pi-top-usb-setup*.tar.gz
 
       - name: Authenticate with GCP

--- a/.github/workflows/create-usb-setup-file.yml
+++ b/.github/workflows/create-usb-setup-file.yml
@@ -103,8 +103,64 @@ jobs:
           sudo mv ${{ matrix.PACKAGES_FOLDER_NAME }} pi-top-usb-setup/
           sudo chown -R $USER:$USER pi-top-usb-setup
           sudo chmod -R 755 pi-top-usb-setup
+          tar -czvf pi-top-usb-setup-${{ matrix.DISTRO }}.tar.gz pi-top-usb-setup
+          ls -lhR
+
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: files-${{ matrix.DISTRO }}
+          path: |
+            packages.list
+            pi-top-usb-setup*.tar.gz
+
+      - name: Authenticate with GCP
+        uses: "google-github-actions/auth@v1.1.1"
+        if: github.ref == 'refs/heads/master'
+        with:
+          credentials_json: ${{ secrets.WEB_GCR_UPLOAD_KEY }}
+
+      - name: Upload to GCS
+        uses: google-github-actions/upload-cloud-storage@v1.0.3
+        if: github.ref == 'refs/heads/master'
+        with:
+          path: "."
+          glob: "pi-top-usb-setup-${{ matrix.DISTRO }}.tar.gz"
+          parent: false
+          destination: "${{ secrets.GCS_PACKAGES_UPLOAD_BUCKET }}/"
+
+      - name: Report to slack
+        if: github.ref == 'refs/heads/master' && always()
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          channel-id: 'C02UEAAHK3R'
+          slack-message: "pi-top-Offline-Updates: create-usb-setup-file workflow run for ${{ matrix.DISTRO }}.\nStatus: ${{ job.status }}\nUrl: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_PACKAGE_PROMOTER_TOKEN }}
+
+  create-combined-bundle-file:
+    runs-on: ubuntu-20.04
+    needs: [download-packages]
+    steps:
+      - name: Download artifacts from previous job
+        uses: actions/download-artifact@v4
+        with:
+            pattern: files-*
+
+      - name: Extract files and combine them
+        run: |
+          mkdir -p pi-top-usb-setup
+          tar -xvf files-bullseye/pi-top-usb-setup-bullseye.tar.gz -C pi-top-usb-setup
+          tar -xvf files-bookworm/pi-top-usb-setup-bookworm.tar.gz -C pi-top-usb-setup
           tar -czvf pi-top-usb-setup.tar.gz pi-top-usb-setup
           ls -lhR
+
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: files-all
+          path: |
+            pi-top-usb-setup.tar.gz
 
       - name: Authenticate with GCP
         uses: "google-github-actions/auth@v1.1.1"
@@ -121,19 +177,11 @@ jobs:
           parent: false
           destination: "${{ secrets.GCS_PACKAGES_UPLOAD_BUCKET }}/"
 
-      - name: Upload as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: files
-          path: |
-            packages.list
-            pi-top-usb-setup.tar.gz
-
       - name: Report to slack
         if: github.ref == 'refs/heads/master' && always()
         uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: 'C02UEAAHK3R'
-          slack-message: "pi-top-Offline-Updates: create-usb-setup-file workflow run.\nStatus: ${{ job.status }}\nUrl: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "pi-top-Offline-Updates: create-usb-setup-file workflow run for combined bundle.\nStatus: ${{ job.status }}\nUrl: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_PACKAGE_PROMOTER_TOKEN }}

--- a/.github/workflows/create-usb-setup-file.yml
+++ b/.github/workflows/create-usb-setup-file.yml
@@ -72,8 +72,9 @@ jobs:
         if: steps.cache-packages.outputs.cache-hit == 'true'
         run: |
           ls -lh
-          tar -xf "${{ matrix.COMPRESSED_UPDATES_FILENAME }}"
-          ls -lh "${{ matrix.PACKAGES_FOLDER_NAME }}"
+          tar -xf updates.tar.gz
+          ls -lh "${{ env.PACKAGES_FOLDER }}"
+          rm -f updates.tar.gz
 
       - name: Mount OS Image root partition
         uses: jcapona/mount-image-partition-action@v0.3
@@ -92,6 +93,11 @@ jobs:
             ls -lh
             bash ./download-packages.sh "${{ matrix.PACKAGES_FOLDER_NAME }}" "${{ matrix.COMPRESSED_UPDATES_FILENAME }}"
           EOF
+
+      - name: Delete OS image to save space
+        run: |
+          sudo umount "${{ env.MOUNT_POINT }}" || true
+          rm -f "${{ env.IMAGE_FILE }}"
 
       - name: List downloaded packages
         run: |
@@ -154,6 +160,7 @@ jobs:
           tar -xvf files-bookworm/pi-top-usb-setup-bookworm.tar.gz
           tar -czvf pi-top-usb-setup.tar.gz pi-top-usb-setup
           ls -lhR
+          rm -rf pi-top-usb-setup
 
       - name: Upload as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/create-usb-setup-file.yml
+++ b/.github/workflows/create-usb-setup-file.yml
@@ -154,7 +154,7 @@ jobs:
           mkdir -p pi-top-usb-setup
           tar -xvf files-bullseye/pi-top-usb-setup-bullseye.tar.gz
           tar -xvf files-bookworm/pi-top-usb-setup-bookworm.tar.gz
-          rm -f files-*
+          rm -rf files-*
           tar -czvf pi-top-usb-setup.tar.gz pi-top-usb-setup
           ls -lhR
           rm -rf pi-top-usb-setup

--- a/.github/workflows/create-usb-setup-file.yml
+++ b/.github/workflows/create-usb-setup-file.yml
@@ -71,22 +71,6 @@ jobs:
           wget "${{ matrix.PI_TOP_OS_URL }}" -O pi-topOS.zip
           unzip pi-topOS.zip
 
-      - name: Cache packages
-        uses: actions/cache@v3
-        id: cache-packages
-        with:
-          path: |
-            "${{ matrix.COMPRESSED_UPDATES_FILENAME }}"
-          key: ${{ runner.os }}-packages-${{ matrix.DISTRO }}
-
-      - name: Extract cached debs
-        if: steps.cache-packages.outputs.cache-hit == 'true'
-        run: |
-          ls -lh
-          tar -xf updates.tar.gz
-          ls -lh "${{ env.PACKAGES_FOLDER }}"
-          rm -f updates.tar.gz
-
       - name: Mount OS Image root partition
         uses: jcapona/mount-image-partition-action@v0.3
         with:
@@ -121,6 +105,7 @@ jobs:
           sudo chown -R $USER:$USER pi-top-usb-setup
           sudo chmod -R 755 pi-top-usb-setup
           tar -czvf pi-top-usb-setup-${{ matrix.DISTRO }}.tar.gz pi-top-usb-setup
+          sudo rm -rf pi-top-usb-setup
           ls -lhR
 
       - name: Upload as artifact
@@ -169,6 +154,7 @@ jobs:
           mkdir -p pi-top-usb-setup
           tar -xvf files-bullseye/pi-top-usb-setup-bullseye.tar.gz
           tar -xvf files-bookworm/pi-top-usb-setup-bookworm.tar.gz
+          rm -f files-*
           tar -czvf pi-top-usb-setup.tar.gz pi-top-usb-setup
           ls -lhR
           rm -rf pi-top-usb-setup

--- a/.github/workflows/create-usb-setup-file.yml
+++ b/.github/workflows/create-usb-setup-file.yml
@@ -37,6 +37,17 @@ jobs:
       id-token: "write"
 
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
       - name: GitHub Environment Variables Action
         uses: FranzDiebold/github-env-vars-action@v2.7.0
 

--- a/.github/workflows/create-usb-setup-file.yml
+++ b/.github/workflows/create-usb-setup-file.yml
@@ -14,15 +14,23 @@ on:
   workflow_dispatch:
 
 env:
-  PI_TOP_OS_URL: "https://storage.googleapis.com/pt-os-release/pi-topOS-bullseye/pi-topOS_bullseye_release_armhf_2023-05-23_B25.zip"
   MOUNT_POINT: "/tmp/pi-top-os"
-  PACKAGES_FOLDER: "updates"
 
 jobs:
-  # TODO: add job to download packages for bookworm once the OS image is out
-  # bookworm updates should be in a folder called 'updates_bookworm'
   download-packages:
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - DISTRO: "bullseye"
+            PI_TOP_OS_URL: "https://storage.googleapis.com/pt-os-release/pi-topOS-bullseye/pi-topOS_bullseye_release_armhf_2023-05-23_B25.zip"
+            PACKAGES_FOLDER_NAME: "updates"
+            COMPRESSED_UPDATES_FILENAME: "updates.tar.gz"
+          - DISTRO: "bookworm"
+            PI_TOP_OS_URL: "https://storage.googleapis.com/pt-os-release/pi-topOS-bookworm/pi-topOS_bookworm_release_armhf_2024-08-06_B62.zip"
+            PACKAGES_FOLDER_NAME: "updates_bookworm"
+            COMPRESSED_UPDATES_FILENAME: "updates_bookworm.tar.gz"
 
     permissions:
       contents: "read"
@@ -45,11 +53,11 @@ jobs:
 
       - name: Get pi-topOS image filename
         run: |
-          echo "IMAGE_FILE=$(basename ${{ env.PI_TOP_OS_URL }} | cut -d'.' -f1).img" >> $GITHUB_ENV
+          echo "IMAGE_FILE=$(basename ${{ matrix.PI_TOP_OS_URL }} | cut -d'.' -f1).img" >> $GITHUB_ENV
 
       - name: Download pi-topOS image
         run: |
-          wget "${{ env.PI_TOP_OS_URL }}" -O pi-topOS.zip
+          wget "${{ matrix.PI_TOP_OS_URL }}" -O pi-topOS.zip
           unzip pi-topOS.zip
 
       - name: Cache packages
@@ -57,15 +65,15 @@ jobs:
         id: cache-packages
         with:
           path: |
-            updates.tar.gz
-          key: ${{ runner.os }}-packages
+            "${{ matrix.COMPRESSED_UPDATES_FILENAME }}"
+          key: ${{ runner.os }}-packages-${{ matrix.DISTRO }}
 
       - name: Extract cached debs
         if: steps.cache-packages.outputs.cache-hit == 'true'
         run: |
           ls -lh
-          tar -xf updates.tar.gz
-          ls -lh "${{ env.PACKAGES_FOLDER }}"
+          tar -xf "${{ matrix.COMPRESSED_UPDATES_FILENAME }}"
+          ls -lh "${{ matrix.PACKAGES_FOLDER_NAME }}"
 
       - name: Mount OS Image root partition
         uses: jcapona/mount-image-partition-action@v0.3
@@ -82,17 +90,17 @@ jobs:
             DEBIAN_FRONTEND=noninteractive apt dist-upgrade -y
             cd /packages
             ls -lh
-            bash ./download-packages.sh
+            bash ./download-packages.sh "${{ matrix.PACKAGES_FOLDER_NAME }}" "${{ matrix.COMPRESSED_UPDATES_FILENAME }}"
           EOF
 
       - name: List downloaded packages
         run: |
-          ls -lh "${{ env.PACKAGES_FOLDER }}"
+          ls -lh "${{ matrix.PACKAGES_FOLDER_NAME }}"
 
       - name: Compress downloaded packages
         run: |
           mkdir -p pi-top-usb-setup
-          sudo mv ${{ env.PACKAGES_FOLDER }} pi-top-usb-setup/
+          sudo mv ${{ matrix.PACKAGES_FOLDER_NAME }} pi-top-usb-setup/
           sudo chown -R $USER:$USER pi-top-usb-setup
           sudo chmod -R 755 pi-top-usb-setup
           tar -czvf pi-top-usb-setup.tar.gz pi-top-usb-setup

--- a/.github/workflows/create-usb-setup-file.yml
+++ b/.github/workflows/create-usb-setup-file.yml
@@ -150,8 +150,8 @@ jobs:
       - name: Extract files and combine them
         run: |
           mkdir -p pi-top-usb-setup
-          tar -xvf files-bullseye/pi-top-usb-setup-bullseye.tar.gz -C pi-top-usb-setup
-          tar -xvf files-bookworm/pi-top-usb-setup-bookworm.tar.gz -C pi-top-usb-setup
+          tar -xvf files-bullseye/pi-top-usb-setup-bullseye.tar.gz
+          tar -xvf files-bookworm/pi-top-usb-setup-bookworm.tar.gz
           tar -czvf pi-top-usb-setup.tar.gz pi-top-usb-setup
           ls -lhR
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^.*\.snap$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer
@@ -20,8 +20,8 @@ repos:
     hooks:
     - id: black
 
--   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.2
+-   repo: https://github.com/hhatto/autopep8
+    rev: v2.3.1
     hooks:
     - id: autopep8
 
@@ -32,8 +32,8 @@ repos:
       name: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.10.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-all]
-        args: ["--python-version=3.7", "--ignore-missing-imports", "--install-types", "--non-interactive"]
+        args: ["--ignore-missing-imports", "--install-types", "--non-interactive"]

--- a/download-packages.sh
+++ b/download-packages.sh
@@ -62,8 +62,8 @@ download_packages() {
     cd "${PACKAGES_FOLDER}"
     while IFS= read -r package; do
         download_package "${package}" &
-        # Limit number of parallel downloads to 2
-        while [ $(jobs | wc -l) -ge 2 ]; do
+        # Limit number of parallel downloads to 4
+        while [ $(jobs | wc -l) -ge 4 ]; do
             sleep 0.5
         done
     done <"${PACKAGES_FILE}"

--- a/download-packages.sh
+++ b/download-packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-PACKAGES_FOLDER="updates"
-COMPRESSED_FILE="updates.tar.gz"
+PACKAGES_FOLDER="${1:-updates}"
+COMPRESSED_FILE="${2:-updates.tar.gz}"
 CURR_FOLDER="$(pwd)"
 PACKAGES_FILE="${CURR_FOLDER}/packages.list"
 


### PR DESCRIPTION
- Run a job using a matrix strategy to generate a bundle file for bullseye and bookworm.
- After the job with the matrix strategy finishes, another job starts that will generate a combined bundle file for both distros.
- Download packages in parallel to reduce job run time.
- Added an error log to the download script to print any packages that failed to download.