### PR TITLE
Add disk space to OS image on CI to avoid running out of space

### DIFF
--- a/.github/workflows/create-usb-setup-file.yml
+++ b/.github/workflows/create-usb-setup-file.yml
@@ -82,11 +82,23 @@ jobs:
       - name: Update pi-topOS container and download packages
         run: |
           sudo systemd-nspawn --pipe --bind "$PWD":/packages  -D "${{ env.MOUNT_POINT }}" /bin/bash << EOF
+            # Use /packages/tmp as a temporary directory to store the apt cache
+            mkdir -p /packages/tmp
+            mv -i /var/cache/apt /packages/tmp
+            ln -s /packages/tmp /var/cache/apt
+
+            # Update system and download packages
             apt update
             DEBIAN_FRONTEND=noninteractive apt dist-upgrade -y
             cd /packages
             ls -lh
             bash ./download-packages.sh "${{ matrix.PACKAGES_FOLDER_NAME }}" "${{ matrix.COMPRESSED_UPDATES_FILENAME }}"
+
+            # Cleanup
+            apt-get clean
+            unlink /var/cache/apt
+            mv /packages/tmp/apt /var/cache
+            rm -rf /packages/tmp
           EOF
 
       - name: Delete OS image to save space

--- a/.github/workflows/create-usb-setup-file.yml
+++ b/.github/workflows/create-usb-setup-file.yml
@@ -72,21 +72,16 @@ jobs:
           unzip pi-topOS.zip
 
       - name: Mount OS Image root partition
-        uses: jcapona/mount-image-partition-action@v0.3
+        uses: jcapona/mount-image-partition-action@v1.0
         with:
           imagePath: ${{ env.IMAGE_FILE }}
           mountPoint: ${{ env.MOUNT_POINT }}
-          partitionIndex: 3
-          filesystem: ext4
+          partitionIndex: 4
+          extraDiskSpace: 1024
 
       - name: Update pi-topOS container and download packages
         run: |
           sudo systemd-nspawn --pipe --bind "$PWD":/packages  -D "${{ env.MOUNT_POINT }}" /bin/bash << EOF
-            # Use /packages/tmp as a temporary directory to store the apt cache
-            mkdir -p /packages/tmp
-            mv -i /var/cache/apt /packages/tmp
-            ln -s /packages/tmp /var/cache/apt
-
             # Update system and download packages
             apt update
             DEBIAN_FRONTEND=noninteractive apt dist-upgrade -y
@@ -96,9 +91,6 @@ jobs:
 
             # Cleanup
             apt-get clean
-            unlink /var/cache/apt
-            mv /packages/tmp/apt /var/cache
-            rm -rf /packages/tmp
           EOF
 
       - name: Delete OS image to save space

--- a/download-packages.sh
+++ b/download-packages.sh
@@ -47,12 +47,16 @@ download_package() {
     CMD_OUTPUT=$(eval "${DOWNLOAD_CMD}")
     # Retry on failure
     if [ $? -ne 0 ]; then
-        echo "Failed to download package ${package}. Retrying with latest version..."
+        echo "Failed to download package ${package}. Retrying ..."
         sleep 1
 
-        DOWNLOAD_CMD="apt download ${package_name} &>/dev/null"
         # Retry a few times before giving up
         for i in {1..10}; do
+            # After a few attempts, try to download the latest version
+            if [ $i -eq 7 ]; then
+                DOWNLOAD_CMD="apt download ${package_name} &>/dev/null"
+                echo "Failed to download package ${package}. Retrying with latest version..."
+            fi
             CMD_OUTPUT=$(eval "${DOWNLOAD_CMD}")
             echo "Downloading ${package_name}, retry ${i}..."
             if [ $? -eq 0 ]; then


### PR DESCRIPTION
Use latest version of action to mount OS image to add free disk space; this allows to upgrade the image and download packages without running out of space.