### PR TITLE
Use state file to run/skip setup stages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,8 @@ a udev rule starts a systemd service that extracts the tarball and runs the setu
 The setup script updates the system using a local apt repository with the files in the USB drive,
 and the uses a JSON file to set the locales, language, keyboard layout and wi-fi network.
 
+Each step of the setup process is optional and can be disabled by setting the corresponding
+key to `false` in the JSON file located in `/var/lib/pi-top-usb-setup/state.cfg`.
 
 -------------------------------------------
 File structure for pi-top-usb-setup.tar.gz
@@ -25,6 +27,12 @@ File structure for pi-top-usb-setup.tar.gz
 
     pi-top-usb-setup/
         pi-top_config.json
+        certificates/
+            # certificates to install
+            ca-certificates/
+                cert1.crt
+                cert2.crt
+                ...
         files/
             # files to copy to root of pi-top
             # e.g. to copy certificates create this nested folder structure
@@ -71,3 +79,24 @@ Sample JSON file to configure the device:
             },
         },
     }
+
+
+--------------------------------
+State configuration file
+--------------------------------
+
+The application configuration file is located in `/var/lib/pi-top-usb-setup/state.cfg` and
+contains the state of the setup process.
+
+A sample of the file with the default values is the following:
+
+.. code-block:: text
+
+    [app]
+    install_update = true
+    install_certificates = true
+    copy_files = true
+    run_scripts = true
+    install_network = true
+    complete_onboarding = true
+    configure_device = true

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ The setup script updates the system using a local apt repository with the files 
 and the uses a JSON file to set the locales, language, keyboard layout and wi-fi network.
 
 Each step of the setup process is optional and can be disabled by setting the corresponding
-key to `false` in the JSON file located in `/var/lib/pi-top-usb-setup/state.cfg`.
+key to `false` in the file located in `/var/lib/pi-top-usb-setup/state.cfg`.
 
 -------------------------------------------
 File structure for pi-top-usb-setup.tar.gz

--- a/debian/pi-top-usb-setup.postinst
+++ b/debian/pi-top-usb-setup.postinst
@@ -5,6 +5,25 @@ case "$1" in
     # Reload udev
     udevadm control --reload-rules
     udevadm trigger
+
+    # Create state file if it doesn't exist
+    STATE_FILE="/var/lib/pi-top-usb-setup/state.cfg"
+    if [ ! -f "$STATE_FILE" ]; then
+      echo "Creating state file in $STATE_FILE with default values"
+      mkdir -p "$(dirname "$STATE_FILE")"
+      cat >"${STATE_FILE}" <<EOL
+[app]
+install_update = true
+install_certificates = true
+copy_files = true
+run_scripts = true
+install_network = true
+complete_onboarding = true
+configure_device = true
+EOL
+    else
+      echo "State file already exists, not overwriting..."
+    fi
   ;;
 
 \

--- a/debian/pi-top-usb-setup.postrm
+++ b/debian/pi-top-usb-setup.postrm
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+case "$1" in
+    remove | purge)
+        STATE_DIR="/var/lib/pi-top-usb-setup"
+        if [ -d "$STATE_DIR" ]; then
+            echo "Removing state directory in $STATE_DIR"
+            rm -rf "$STATE_DIR"
+        fi
+    ;;
+
+    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    ;;
+
+    *)
+        echo "postrm called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/pi_top_usb_setup/__main__.py
+++ b/pi_top_usb_setup/__main__.py
@@ -17,8 +17,10 @@ click_logging.basic_config(logger)
 @click.version_option()
 @click.argument("mount_point", type=click.Path(exists=True))
 @click.option("--skip-dialog", is_flag=True)
-@click.option("--skip-update", is_flag=True)
-def main(mount_point, skip_dialog, skip_update) -> None:
+def main(
+    mount_point,
+    skip_dialog,
+) -> None:
     try:
         AppFilesystem(mount_point)
     except Exception as e:
@@ -27,8 +29,6 @@ def main(mount_point, skip_dialog, skip_update) -> None:
 
     if skip_dialog:
         os.environ["PT_USB_SETUP_SKIP_DIALOG"] = "1"
-    if skip_update:
-        os.environ["PT_USB_SETUP_SKIP_UPDATE"] = "1"
     if mount_point:
         os.environ["PT_USB_SETUP_MOUNT_POINT"] = mount_point
 

--- a/pi_top_usb_setup/pages/run_setup.py
+++ b/pi_top_usb_setup/pages/run_setup.py
@@ -4,6 +4,7 @@ from enum import Enum
 from threading import Thread
 from typing import Callable
 
+from pitop.common.state_manager import StateManager
 from pt_miniscreen.components.mixins import HasGutterIcons
 from pt_miniscreen.components.progress_bar import ProgressBar
 from pt_miniscreen.core.component import Component
@@ -50,6 +51,16 @@ class TextWithDots:
         return f"{self.base} {self.dots}"
 
 
+class ConfigFileKeys(Enum):
+    INSTALL_UPDATE = "install_update"
+    INSTALL_CERTIFICATES = "install_certificates"
+    COPY_FILES = "copy_files"
+    RUN_SCRIPTS = "run_scripts"
+    INSTALL_NETWORK = "install_network"
+    COMPLETE_ONBOARDING = "complete_onboarding"
+    CONFIGURE_DEVICE = "configure_device"
+
+
 # Use enum value to represent 'starting' progress %
 class RunStates(Enum):
     ERROR = -1
@@ -61,6 +72,7 @@ class RunStates(Enum):
     COPYING_FILES = 85
     COMPLETING_ONBOARDING = 90
     RUNNING_SCRIPTS = 95
+    CONFIGURING_NETWORK = 98
     DONE = 100
 
 
@@ -74,6 +86,7 @@ class AppErrors(Enum):
     COPY_ERROR = 6
     SCRIPTS_ERROR = 7
     CERTIFICATE_INSTALLATION_ERROR = 8
+    NETWORK_CONFIGURATION_ERROR = 9
 
 
 class RunSetupPage(Component, HasGutterIcons):
@@ -90,6 +103,12 @@ class RunSetupPage(Component, HasGutterIcons):
             },
             **kwargs,
         )
+
+        self.state_manager = None
+        try:
+            self.state_manager = StateManager("pi-top-usb-setup")
+        except Exception as e:
+            logger.error(f"Couldn't create state manager: {e}")
 
         try:
             self.fs = AppFilesystem(mount_point=os.environ["PT_USB_SETUP_MOUNT_POINT"])
@@ -118,6 +137,9 @@ class RunSetupPage(Component, HasGutterIcons):
             # Extract compressed file
             self._extract_file()
 
+            # Read JSON file
+            self.fs.read_config_file()
+
             # Umount USB drive
             self.fs.umount_usb_drive()
 
@@ -135,6 +157,9 @@ class RunSetupPage(Component, HasGutterIcons):
 
             # Run scripts
             self._run_scripts()
+
+            # Configure network
+            self._set_network()
 
             # Finish onboarding if necessary
             self._complete_onboarding()
@@ -179,9 +204,22 @@ class RunSetupPage(Component, HasGutterIcons):
             )
             raise
 
+    def _should_run(self, stage: ConfigFileKeys) -> bool:
+        should_run = False
+        try:
+            should_run = isinstance(
+                self.state_manager, StateManager
+            ) and self.state_manager.get("app", stage.value, "false") in (
+                "true",
+                "1",
+            )
+        except Exception as e:
+            logger.error(f"Error getting state manager: {e}")
+        return should_run
+
     def _update_system(self):
-        if os.environ.get("PT_USB_SETUP_SKIP_UPDATE", "0") == "1":
-            logger.info("Skipping system update; script called with --skip-update")
+        if not self._should_run(ConfigFileKeys.INSTALL_UPDATE):
+            logger.warning("Skipping system update due to system configuration...")
             return
 
         try:
@@ -233,6 +271,12 @@ class RunSetupPage(Component, HasGutterIcons):
             raise Exception(f"Update Error: {e}")
 
     def _configure_device(self):
+        if not self._should_run(ConfigFileKeys.CONFIGURE_DEVICE):
+            logger.warning(
+                "Skipping device configuration due to system configuration..."
+            )
+            return
+
         self.state.update({"run_state": RunStates.CONFIGURING_DEVICE})
         try:
             self.fs.configure_device(
@@ -246,7 +290,35 @@ class RunSetupPage(Component, HasGutterIcons):
             )
             raise Exception(f"Config Error: {e}")
 
+    def _set_network(self):
+        if not self._should_run(ConfigFileKeys.INSTALL_NETWORK):
+            logger.warning(
+                "Skipping network configuration due to system configuration..."
+            )
+            return
+
+        self.state.update({"run_state": RunStates.CONFIGURING_NETWORK})
+        try:
+            self.fs.set_network(
+                on_progress=lambda percentage: self.state.update(
+                    {"network_progress": percentage}
+                ),
+            )
+        except Exception:
+            self.state.update(
+                {
+                    "run_state": RunStates.ERROR,
+                    "error": AppErrors.NETWORK_CONFIGURATION_ERROR,
+                }
+            )
+
     def _install_certificates(self):
+        if not self._should_run(ConfigFileKeys.INSTALL_CERTIFICATES):
+            logger.warning(
+                "Skipping certificate installation due to system configuration..."
+            )
+            return
+
         self.state.update({"run_state": RunStates.INSTALLING_CERTIFICATES})
         try:
             self.fs.install_certificates(
@@ -264,6 +336,10 @@ class RunSetupPage(Component, HasGutterIcons):
             raise Exception(f"Certificate Installation Error: {e}")
 
     def _copy_files_to_device(self):
+        if not self._should_run(ConfigFileKeys.COPY_FILES):
+            logger.warning("Skipping files copy due to system configuration...")
+            return
+
         self.state.update({"run_state": RunStates.COPYING_FILES})
         try:
             self.fs.copy_files(
@@ -278,6 +354,10 @@ class RunSetupPage(Component, HasGutterIcons):
             raise Exception(f"Copy Error: {e}")
 
     def _complete_onboarding(self):
+        if not self._should_run(ConfigFileKeys.COMPLETE_ONBOARDING):
+            logger.warning("Skipping onboarding due to system configuration...")
+            return
+
         self.state.update({"run_state": RunStates.COMPLETING_ONBOARDING})
         try:
             self.fs.complete_onboarding(
@@ -292,6 +372,10 @@ class RunSetupPage(Component, HasGutterIcons):
             raise Exception(f"Onboarding Error: {e}")
 
     def _run_scripts(self):
+        if not self._should_run(ConfigFileKeys.RUN_SCRIPTS):
+            logger.warning("Skipping scripts run due to system configuration...")
+            return
+
         self.state.update({"run_state": RunStates.RUNNING_SCRIPTS})
         try:
             self.fs.run_scripts(
@@ -345,6 +429,12 @@ class RunSetupPage(Component, HasGutterIcons):
         elif state is RunStates.RUNNING_SCRIPTS:
             value += (
                 self.state.get("scripts_progress", 0)
+                / 100
+                * (RunStates.CONFIGURING_NETWORK.value - value)
+            )
+        elif state is RunStates.CONFIGURING_NETWORK:
+            value += (
+                self.state.get("network_progress", 0)
                 / 100
                 * (RunStates.COMPLETING_ONBOARDING.value - value)
             )

--- a/pi_top_usb_setup/pages/run_setup.py
+++ b/pi_top_usb_setup/pages/run_setup.py
@@ -69,10 +69,10 @@ class RunStates(Enum):
     UPDATING_SYSTEM = 25
     CONFIGURING_DEVICE = 80
     INSTALLING_CERTIFICATES = 82
+    CONFIGURING_NETWORK = 83
     COPYING_FILES = 85
-    COMPLETING_ONBOARDING = 90
-    RUNNING_SCRIPTS = 95
-    CONFIGURING_NETWORK = 98
+    RUNNING_SCRIPTS = 90
+    COMPLETING_ONBOARDING = 95
     DONE = 100
 
 
@@ -100,6 +100,10 @@ class RunSetupPage(Component, HasGutterIcons):
                 "tar_progress": 0,
                 "config_progress": 0,
                 "onboarding_progress": 0,
+                "scripts_progress": 0,
+                "certificate_progress": 0,
+                "network_progress": 0,
+                "copy_progress": 0,
             },
             **kwargs,
         )
@@ -152,14 +156,14 @@ class RunSetupPage(Component, HasGutterIcons):
             # Copy certficates over to the device
             self._install_certificates()
 
+            # Configure network
+            self._set_network()
+
             # Copy files over to the device
             self._copy_files_to_device()
 
             # Run scripts
             self._run_scripts()
-
-            # Configure network
-            self._set_network()
 
             # Finish onboarding if necessary
             self._complete_onboarding()
@@ -417,9 +421,14 @@ class RunSetupPage(Component, HasGutterIcons):
             value += (
                 self.state.get("certificate_progress", 0)
                 / 100
+                * (RunStates.CONFIGURING_NETWORK.value - value)
+            )
+        elif state is RunStates.CONFIGURING_NETWORK:
+            value += (
+                self.state.get("network_progress", 0)
+                / 100
                 * (RunStates.COPYING_FILES.value - value)
             )
-
         elif state is RunStates.COPYING_FILES:
             value += (
                 self.state.get("copy_progress", 0)
@@ -430,15 +439,15 @@ class RunSetupPage(Component, HasGutterIcons):
             value += (
                 self.state.get("scripts_progress", 0)
                 / 100
-                * (RunStates.CONFIGURING_NETWORK.value - value)
-            )
-        elif state is RunStates.CONFIGURING_NETWORK:
-            value += (
-                self.state.get("network_progress", 0)
-                / 100
                 * (RunStates.COMPLETING_ONBOARDING.value - value)
             )
         elif state is RunStates.COMPLETING_ONBOARDING:
+            value += (
+                self.state.get("onboarding_progress", 0)
+                / 100
+                * (RunStates.DONE.value - value)
+            )
+        elif state is RunStates.DONE:
             value += (
                 self.state.get("onboarding_progress", 0)
                 / 100

--- a/pi_top_usb_setup/system_updater.py
+++ b/pi_top_usb_setup/system_updater.py
@@ -86,10 +86,10 @@ class SystemUpdater:
                 raise Exception(f"Command '{cmd}' exited with code '{exit_code}'")
 
     def update(self) -> None:
-        self._run_cmd("sudo apt-get update")
+        self._run_cmd("apt-get update")
 
     def upgrade_package(self, package_name) -> None:
-        self._run_cmd(f"sudo apt-get install -y {package_name}")
+        self._run_cmd(f"apt-get install -y {package_name}")
 
     def upgrade(self) -> None:
-        self._run_cmd("sudo apt-get dist-upgrade -y")
+        self._run_cmd("apt-get dist-upgrade -y")


### PR DESCRIPTION
Use a state file to determine which stages of the USB setup process are run/skipped.
Handle creation/removal of file on package installation/removal.